### PR TITLE
feat: add Baw Baw Shire council integration with glass recycling support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,8 +78,13 @@ The app uses Expo Router's file-based routing:
 5. **Convex Backend**
    - Generated types in `convex/_generated/`
    - Backend functions in `convex/` directory:
-     - `councilServices.ts` - Council data fetching logic
+     - `councilServices.ts` - Council data fetching logic with WasteCollectionDates type
      - `councils/monash.ts` - Monash council specific implementation
+     - `councils/alpineShire.ts` - Alpine Shire council specific implementation
+     - `councils/ballarat.ts` - City of Ballarat council specific implementation
+     - `councils/banyule.ts` - Banyule City council specific implementation
+     - `councils/gannawarra.ts` - Gannawarra Shire council specific implementation
+     - `councils/bawBawShire.ts` - Baw Baw Shire council specific implementation
      - `googlePlaces.ts` - Google Places API integration
    - Use Convex React hooks for data fetching
 
@@ -95,11 +100,14 @@ The app uses Expo Router's file-based routing:
    - Monash Council waste collection API
    - Alpine Shire waste collection API
    - City of Ballarat waste collection API
+   - Banyule City waste collection API
+   - Gannawarra Shire waste collection API
+   - Baw Baw Shire waste collection API
    - Extensible pattern for adding more councils
 
 ### Utilities
 
-- `lib/addressExtractor.ts` - Extract address components from Google Places data and format search addresses
+- `lib/addressExtractor.ts` - Extract address components from Google Places data and format search addresses (supports council-specific formatting)
 - `lib/distance.ts` - Calculate distances between coordinates
 - `lib/env.ts` - Environment variable validation with envalid
 
@@ -119,11 +127,13 @@ The app uses Expo Router's file-based routing:
   - City of Ballarat
   - City of Banyule
   - Gannawarra Shire
+  - Baw Baw Shire
 - Fetches waste collection dates for:
   - Landfill waste
   - Recycling
   - Food & garden waste
   - Hard waste
+  - Glass recycling (where available)
 
 ### Type Definitions
 

--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -449,6 +449,32 @@ export default function SearchScreen() {
 														</ThemedText>
 													</View>
 												</View>
+
+												{/* Glass Recycling */}
+												{councilData.result.glass && (
+													<View style={styles.wasteItem}>
+														<View
+															style={[
+																styles.wasteIconContainer,
+																{ backgroundColor: "#00ACC120" },
+															]}
+														>
+															<IconSymbol
+																name="wineglass"
+																size={20}
+																color="#00ACC1"
+															/>
+														</View>
+														<View style={styles.wasteContent}>
+															<ThemedText style={styles.wasteType}>
+																Glass Recycling
+															</ThemedText>
+															<ThemedText style={styles.wasteDate}>
+																{formatDate(councilData.result.glass)}
+															</ThemedText>
+														</View>
+													</View>
+												)}
 											</View>
 										) : (
 											<ThemedText style={styles.councilUnsupported}>

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -17,6 +17,7 @@ import type * as councilServices from "../councilServices.js";
 import type * as councils_alpineShire from "../councils/alpineShire.js";
 import type * as councils_ballarat from "../councils/ballarat.js";
 import type * as councils_banyule from "../councils/banyule.js";
+import type * as councils_bawBawShire from "../councils/bawBawShire.js";
 import type * as councils_gannawarra from "../councils/gannawarra.js";
 import type * as councils_monash from "../councils/monash.js";
 import type * as googlePlaces from "../googlePlaces.js";
@@ -34,6 +35,7 @@ declare const fullApi: ApiFromModules<{
   "councils/alpineShire": typeof councils_alpineShire;
   "councils/ballarat": typeof councils_ballarat;
   "councils/banyule": typeof councils_banyule;
+  "councils/bawBawShire": typeof councils_bawBawShire;
   "councils/gannawarra": typeof councils_gannawarra;
   "councils/monash": typeof councils_monash;
   googlePlaces: typeof googlePlaces;

--- a/convex/councilServices.ts
+++ b/convex/councilServices.ts
@@ -4,6 +4,7 @@ import { action } from "./_generated/server";
 import { fetchAlpineShireData } from "./councils/alpineShire";
 import { fetchBallaratData } from "./councils/ballarat";
 import { fetchBanyuleData } from "./councils/banyule";
+import { fetchBawBawShireData } from "./councils/bawBawShire";
 import { fetchGannawarraData } from "./councils/gannawarra";
 import { fetchMonashData } from "./councils/monash";
 
@@ -12,6 +13,7 @@ export type WasteCollectionDates = {
 	recycling: number | null;
 	foodAndGardenWaste: number | null;
 	hardWaste: number | null;
+	glass: number | null;
 };
 
 export type CouncilData = {
@@ -31,6 +33,7 @@ const councilHandlers: Record<
 	"City of Ballarat": fetchBallaratData,
 	"Banyule City": fetchBanyuleData,
 	"Gannawarra Shire": fetchGannawarraData,
+	"Baw Baw Shire": fetchBawBawShireData,
 };
 
 export const getCouncilData = action({

--- a/convex/councils/alpineShire.ts
+++ b/convex/councils/alpineShire.ts
@@ -42,6 +42,7 @@ function parseAlpineShireWasteData(html: string): WasteCollectionDates {
 		recycling: null,
 		foodAndGardenWaste: null,
 		hardWaste: null,
+		glass: null,
 	};
 
 	// Parse Waste Collection date

--- a/convex/councils/ballarat.ts
+++ b/convex/councils/ballarat.ts
@@ -60,6 +60,7 @@ function parseBallaratWasteData(
 		recycling: null,
 		foodAndGardenWaste: null,
 		hardWaste: null,
+		glass: null,
 	};
 
 	// Parse waste collection dates

--- a/convex/councils/banyule.ts
+++ b/convex/councils/banyule.ts
@@ -57,6 +57,7 @@ function parseWasteCollectionDates(html: string): WasteCollectionDates {
 		recycling: null,
 		foodAndGardenWaste: null,
 		hardWaste: null,
+		glass: null,
 	};
 
 	// Parse Rubbish (Landfill Waste) date

--- a/convex/councils/bawBawShire.ts
+++ b/convex/councils/bawBawShire.ts
@@ -1,0 +1,477 @@
+import { DateTime } from "luxon";
+import {
+	extractAddressComponents,
+	getSearchAddress,
+} from "@/lib/addressExtractor";
+import type { GooglePlaceDetails } from "@/types/googlePlaces";
+import type { WasteCollectionDates } from "../councilServices";
+
+type FormResponse = {
+	name: string;
+	forms: {
+		name: string;
+		templateId: string;
+		type: string;
+		subType: string;
+	}[];
+};
+
+type AddressSearchResponse = {
+	header: {
+		warning: string;
+		authUser: string;
+		sessionId: string;
+	};
+	fullText: {
+		selectionLayer: string;
+		mapKey: string;
+		dbKey: string;
+		displayValue: string;
+	}[];
+	origin: string;
+};
+
+type WasteInfoResponse = {
+	header: {
+		warning: string | null;
+		authUser: string;
+		sessionId: string;
+	};
+	fullText: string | null;
+	extent: {
+		unit: string;
+		bounds: {
+			x1: number;
+			y1: number;
+			x2: number;
+			y2: number;
+		};
+		epsg: string;
+	};
+	origin: string;
+	selectionLayers: {
+		name: string;
+		alias: string;
+		current: boolean;
+	}[];
+	infoPanels: {
+		info1: {
+			count: number;
+			index: number;
+			mapkey: string;
+			layerAlias: string;
+			caption: string;
+			feature: {
+				mapkey: string;
+				fields: {
+					value: {
+						binding: boolean;
+						column: string;
+						defaultValue: string;
+						value: string;
+					};
+					inlineLinks?: boolean;
+					caption: string;
+					type: string;
+					id: string;
+					name: string;
+					source?: {
+						binding: boolean;
+						column: string;
+						defaultValue: string;
+						value: string;
+					};
+					tooltip?: {
+						binding: boolean;
+						column: string;
+						defaultValue: string;
+						value: string;
+					};
+					enableLink?: boolean;
+					linkUrl?: {
+						binding: boolean;
+						column: string;
+						defaultValue: string;
+						value: string;
+					};
+				}[];
+				x: number;
+				y: number;
+				epsg: string;
+			};
+		};
+		info2: {
+			count: number;
+			index: number;
+			dbkey: string;
+			caption: string;
+			feature: unknown | null;
+			fields: {
+				value: {
+					binding: boolean;
+					column: string;
+					defaultValue: string;
+					value: string;
+				};
+				inlineLinks: boolean;
+				caption: string;
+				type: string;
+				id: string;
+				name: string;
+			}[];
+		};
+		info3: unknown | null;
+		databaseConstraints: unknown | null;
+	};
+};
+
+type SessionResponse = {
+	id: string;
+	name: string;
+	modules: string[];
+	moduleList: {
+		id: string;
+		name: string;
+	}[];
+	authorisation: {
+		username: string;
+		authenticationProvider: string;
+	};
+};
+
+async function getSession(): Promise<{
+	sessionId: string;
+	wasteModuleId: string;
+}> {
+	const response = await fetch(
+		"https://webmaps.bawbawshire.vic.gov.au/IntraMaps98/ApplicationEngine/Projects/?configId=00000000-0000-0000-0000-000000000000&appType=MapBuilder&project=700a73fd-2c9c-4b15-962f-07e74d32c0b5&datasetCode=",
+		{
+			method: "POST",
+			headers: {
+				"User-Agent":
+					"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36",
+				"Accept-Encoding": "gzip, deflate, br, zstd",
+				"sec-ch-ua-platform": '"macOS"',
+				"x-requested-with": "XMLHttpRequest",
+				"sec-ch-ua":
+					'"Not)A;Brand";v="8", "Chromium";v="138", "Google Chrome";v="138"',
+				"content-type": "application/json",
+				"sec-ch-ua-mobile": "?0",
+				origin: "https://webmaps.bawbawshire.vic.gov.au",
+				"sec-fetch-site": "same-origin",
+				"sec-fetch-mode": "cors",
+				"sec-fetch-dest": "empty",
+				"accept-language": "en-GB,en-US;q=0.9,en;q=0.8,zh-CN;q=0.7,zh;q=0.6",
+				priority: "u=1, i",
+			},
+		},
+	);
+
+	if (!response.ok) {
+		throw new Error(`Failed to get session: ${response.status}`);
+	}
+
+	const sessionId = response.headers.get("x-intramaps-session");
+	if (!sessionId) {
+		throw new Error("No session ID returned");
+	}
+
+	const data = (await response.json()) as SessionResponse;
+
+	// Find the BawBawNearMe_Waste module
+	const wasteModule = data.moduleList.find(
+		(module) => module.name === "BawBawNearMe_Waste",
+	);
+	if (!wasteModule) {
+		throw new Error("BawBawNearMe_Waste module not found");
+	}
+
+	return { sessionId, wasteModuleId: wasteModule.id };
+}
+
+async function getFormTemplateId(
+	sessionId: string,
+	wasteModuleId: string,
+): Promise<string> {
+	const response = await fetch(
+		`https://webmaps.bawbawshire.vic.gov.au/IntraMaps98/ApplicationEngine/Modules/?IntraMapsSession=${sessionId}`,
+		{
+			method: "POST",
+			headers: {
+				"User-Agent":
+					"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36",
+				"Accept-Encoding": "gzip, deflate, br, zstd",
+				"Content-Type": "application/json",
+				"sec-ch-ua-platform": '"macOS"',
+				"x-requested-with": "XMLHttpRequest",
+				"sec-ch-ua":
+					'"Not)A;Brand";v="8", "Chromium";v="138", "Google Chrome";v="138"',
+				"sec-ch-ua-mobile": "?0",
+				origin: "https://webmaps.bawbawshire.vic.gov.au",
+				"sec-fetch-site": "same-origin",
+				"sec-fetch-mode": "cors",
+				"sec-fetch-dest": "empty",
+				"accept-language": "en-GB,en-US;q=0.9,en;q=0.8,zh-CN;q=0.7,zh;q=0.6",
+				priority: "u=1, i",
+			},
+			body: JSON.stringify({
+				module: wasteModuleId,
+			}),
+		},
+	);
+
+	if (!response.ok) {
+		throw new Error(`Failed to get form: ${response.status}`);
+	}
+
+	const data = (await response.json()) as FormResponse;
+
+	// Find the form with name containing "address[Address]"
+	const addressForm = data.forms.find((form) =>
+		form.name.includes("address[Address]"),
+	);
+
+	if (!addressForm) {
+		throw new Error("Address form not found");
+	}
+
+	return addressForm.templateId;
+}
+
+async function searchAddress(
+	sessionId: string,
+	formTemplateId: string,
+	address: string,
+): Promise<{
+	selectionLayer: string;
+	mapKey: string;
+	dbKey: string;
+}> {
+	const response = await fetch(
+		`https://webmaps.bawbawshire.vic.gov.au/IntraMaps98/ApplicationEngine/Search/?infoPanelWidth=0&mode=Refresh&form=${formTemplateId}&resubmit=false&IntraMapsSession=${sessionId}`,
+		{
+			method: "POST",
+			headers: {
+				"User-Agent":
+					"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36",
+				"Accept-Encoding": "gzip, deflate, br, zstd",
+				"Content-Type": "application/json",
+				"sec-ch-ua-platform": '"macOS"',
+				"x-requested-with": "XMLHttpRequest",
+				"sec-ch-ua":
+					'"Not)A;Brand";v="8", "Chromium";v="138", "Google Chrome";v="138"',
+				"sec-ch-ua-mobile": "?0",
+				origin: "https://webmaps.bawbawshire.vic.gov.au",
+				"sec-fetch-site": "same-origin",
+				"sec-fetch-mode": "cors",
+				"sec-fetch-dest": "empty",
+				"accept-language": "en-GB,en-US;q=0.9,en;q=0.8,zh-CN;q=0.7,zh;q=0.6",
+				priority: "u=1, i",
+			},
+			body: JSON.stringify({
+				fields: [address],
+			}),
+		},
+	);
+
+	if (!response.ok) {
+		throw new Error(`Failed to search address: ${response.status}`);
+	}
+
+	const data = (await response.json()) as AddressSearchResponse;
+
+	if (!data.fullText || data.fullText.length === 0) {
+		throw new Error("No results found for this address");
+	}
+
+	const firstResult = data.fullText[0];
+	return {
+		selectionLayer: firstResult.selectionLayer,
+		mapKey: firstResult.mapKey,
+		dbKey: firstResult.dbKey,
+	};
+}
+
+async function getWasteInfo(
+	sessionId: string,
+	selectionLayer: string,
+	mapKey: string,
+	dbKey: string,
+): Promise<WasteInfoResponse> {
+	const response = await fetch(
+		`https://webmaps.bawbawshire.vic.gov.au/IntraMaps98/ApplicationEngine/Search/Refine/Set?IntraMapsSession=${sessionId}`,
+		{
+			method: "POST",
+			headers: {
+				"User-Agent":
+					"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36",
+				"Accept-Encoding": "gzip, deflate, br, zstd",
+				"Content-Type": "application/json",
+				"sec-ch-ua-platform": '"macOS"',
+				"x-requested-with": "XMLHttpRequest",
+				"sec-ch-ua":
+					'"Not)A;Brand";v="8", "Chromium";v="138", "Google Chrome";v="138"',
+				"sec-ch-ua-mobile": "?0",
+				origin: "https://webmaps.bawbawshire.vic.gov.au",
+				"sec-fetch-site": "same-origin",
+				"sec-fetch-mode": "cors",
+				"sec-fetch-dest": "empty",
+				"accept-language": "en-GB,en-US;q=0.9,en;q=0.8,zh-CN;q=0.7,zh;q=0.6",
+				priority: "u=1, i",
+			},
+			body: JSON.stringify({
+				selectionLayer,
+				mapKey,
+				infoPanelWidth: 0,
+				mode: "Refresh",
+				dbKey,
+				zoomType: "current",
+			}),
+		},
+	);
+
+	if (!response.ok) {
+		throw new Error(`Failed to get waste info: ${response.status}`);
+	}
+
+	const data = (await response.json()) as WasteInfoResponse;
+
+	return data;
+}
+
+function getNextCollectionDate(collectionDay: string): number | null {
+	// Extract the day name from strings like "Thursday (Declared)"
+	const dayMatch = collectionDay.match(/^(\w+)/);
+	if (!dayMatch) return null;
+
+	const dayName = dayMatch[1];
+	const dayMap: Record<string, number> = {
+		Monday: 1,
+		Tuesday: 2,
+		Wednesday: 3,
+		Thursday: 4,
+		Friday: 5,
+		Saturday: 6,
+		Sunday: 7,
+	};
+
+	const targetDay = dayMap[dayName];
+	if (!targetDay) return null;
+
+	// Get current date in Melbourne timezone
+	const now = DateTime.now().setZone("Australia/Melbourne");
+	const currentDay = now.weekday;
+
+	// Calculate days until next collection (inclusive - if today is collection day, show today)
+	let daysUntilCollection: number;
+	if (currentDay <= targetDay) {
+		daysUntilCollection = targetDay - currentDay;
+	} else {
+		daysUntilCollection = 7 - currentDay + targetDay;
+	}
+
+	// Get the next collection date at midnight
+	const nextCollection = now.plus({ days: daysUntilCollection }).startOf("day");
+
+	return Math.floor(nextCollection.toSeconds());
+}
+
+function parseDateString(dateString: string): number | null {
+	// Parse date string like "31/07/2025" to Unix timestamp
+	const match = dateString.match(/(\d{1,2})\/(\d{1,2})\/(\d{4})/);
+	if (!match) return null;
+
+	const [, day, month, year] = match;
+
+	const melbourneDate = DateTime.fromObject(
+		{
+			year: Number.parseInt(year),
+			month: Number.parseInt(month),
+			day: Number.parseInt(day),
+			hour: 0,
+			minute: 0,
+			second: 0,
+		},
+		{ zone: "Australia/Melbourne" },
+	);
+
+	return Math.floor(melbourneDate.toSeconds());
+}
+
+function parseWasteInfoResponse(data: WasteInfoResponse): WasteCollectionDates {
+	const dates: WasteCollectionDates = {
+		landfillWaste: null,
+		recycling: null,
+		foodAndGardenWaste: null,
+		hardWaste: null,
+		glass: null,
+	};
+
+	if (!data.infoPanels?.info1?.feature?.fields) {
+		console.error("Invalid response structure: missing fields");
+		return dates;
+	}
+
+	const fields = data.infoPanels.info1.feature.fields;
+
+	for (const field of fields) {
+		// Skip fields without proper structure
+		if (!field.caption || !field.value?.value) {
+			continue;
+		}
+
+		const caption = field.caption;
+		const value = field.value.value;
+
+		switch (caption) {
+			case "General Rubbish Collection Day":
+				dates.landfillWaste = getNextCollectionDate(value);
+				break;
+			case "Next Mixed Recycling Date":
+				dates.recycling = parseDateString(value);
+				break;
+			case "Next Garden Organics Date":
+				dates.foodAndGardenWaste = parseDateString(value);
+				break;
+			case "Next Glass Recycling Date":
+				dates.glass = parseDateString(value);
+				break;
+		}
+	}
+
+	return dates;
+}
+
+export async function fetchBawBawShireData(placeDetails: GooglePlaceDetails) {
+	const addressComponents = extractAddressComponents(placeDetails);
+	const searchQuery = getSearchAddress(addressComponents, "Baw Baw Shire");
+
+	try {
+		// Step 1: Get session and waste module ID
+		const { sessionId, wasteModuleId } = await getSession();
+
+		// Step 2: Get form template ID
+		const formTemplateId = await getFormTemplateId(sessionId, wasteModuleId);
+
+		// Step 3: Search for address
+		const { selectionLayer, mapKey, dbKey } = await searchAddress(
+			sessionId,
+			formTemplateId,
+			searchQuery,
+		);
+
+		// Step 4: Get waste collection info
+		const wasteInfo = await getWasteInfo(
+			sessionId,
+			selectionLayer,
+			mapKey,
+			dbKey,
+		);
+
+		// Parse and return the waste collection dates
+		return parseWasteInfoResponse(wasteInfo);
+	} catch (error) {
+		console.error("Baw Baw Shire API error:", error);
+		throw new Error("Failed to fetch data from Baw Baw Shire council");
+	}
+}

--- a/convex/councils/gannawarra.ts
+++ b/convex/councils/gannawarra.ts
@@ -56,6 +56,7 @@ function parseWasteCollectionDates(html: string): WasteCollectionDates {
 		recycling: null,
 		foodAndGardenWaste: null,
 		hardWaste: null,
+		glass: null,
 	};
 
 	// Parse General Waste (Landfill Waste) date

--- a/convex/councils/monash.ts
+++ b/convex/councils/monash.ts
@@ -57,6 +57,7 @@ function parseWasteCollectionDates(html: string): WasteCollectionDates {
 		recycling: null,
 		foodAndGardenWaste: null,
 		hardWaste: null,
+		glass: null,
 	};
 
 	// Parse Landfill Waste date

--- a/lib/addressExtractor.ts
+++ b/lib/addressExtractor.ts
@@ -51,13 +51,33 @@ export function extractAddressComponents(
 /**
  * Gets a formatted address string for search queries
  * @param components - Extracted address components
+ * @param council - Optional council name to format address differently
  * @returns Formatted address string for search queries (without state/postcode)
  * @example // Returns "1/26A Ormond Road, Clayton"
  */
 export function getSearchAddress(
 	components: ExtractedAddressComponents,
+	council?: string,
 ): string {
-	return components.subpremise
-		? `${components.subpremise}/${components.streetNumber} ${components.route} ${components.locality}`
-		: `${components.streetNumber} ${components.route} ${components.locality}`.trim();
+	// Construct the address string based on council-specific formatting requirements
+	let address = "";
+
+	switch (council) {
+		case "Baw Baw Shire": {
+			// Baw Baw Shire format excludes locality (suburb)
+			address = components.subpremise
+				? `${components.subpremise}/${components.streetNumber} ${components.route}`
+				: `${components.streetNumber} ${components.route}`;
+			break;
+		}
+		default: {
+			// Standard format includes locality for most councils
+			address = components.subpremise
+				? `${components.subpremise}/${components.streetNumber} ${components.route} ${components.locality}`
+				: `${components.streetNumber} ${components.route} ${components.locality}`;
+		}
+	}
+
+	// Ensure consistent formatting by trimming whitespace and converting to uppercase
+	return address.trim().toUpperCase();
 }


### PR DESCRIPTION
- Implement Baw Baw Shire council waste collection API integration
- Add glass recycling field to WasteCollectionDates type across all councils
- Update UI to display glass recycling dates when available
- Enhance address formatting to support council-specific requirements
- Update documentation to reflect new council support and glass recycling feature