### PR TITLE
feat: standardize error handling across all council implementations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,3 +183,8 @@ The project includes:
 - Luxon 3.5.0 (for date/time handling)
 - envalid 8.0.0 (for environment validation)
 - uuid 11.0.5 (for generating unique identifiers)
+
+## Development Warnings
+
+- Do not run `bun run dev`, `bunx convex dev` or any related server starting command.
+- Do not run `git` related bash commands UNDER ANY CIRCUMSTANCES, unless I instructed you to do so.

--- a/convex/councils/monash.ts
+++ b/convex/councils/monash.ts
@@ -6,13 +6,13 @@ import {
 import { calculateDistance } from "@/lib/distance";
 import type { GooglePlaceDetails } from "@/types/googlePlaces";
 import type { WasteCollectionDates } from "../councilServices";
-import { COUNCIL_NAMES } from "../councils";
 import {
 	AddressNotFoundError,
+	COUNCIL_NAMES,
 	CouncilAPIError,
 	logError,
 	safeJsonParse,
-} from "../councils/errors";
+} from "./index";
 
 type MonashApiResponse = {
 	Items: {


### PR DESCRIPTION
## Summary

- Apply consistent error handling patterns to all 7 council implementations
- Implement typed error classes for better error tracking and debugging
- Clean up import paths and remove debug logging

## Changes

### Error Handling Improvements
- Replace generic `Error` throws with specific error types:
  - `CouncilAPIError` - for HTTP/API failures with status codes
  - `AddressNotFoundError` - for no results/address not found scenarios
  - `InvalidResponseError` - for invalid data structures or missing required data
- Implement `safeJsonParse` utility for all JSON parsing operations
- Add consistent error logging with `logError` utility
- Ensure proper error re-throwing to maintain error type information

### Code Cleanup
- Update import paths to use `./index` instead of relative paths for cleaner imports
- Remove debug `console.log` statements from Ballarat and Bayside implementations
- Standardize error handling patterns across all councils:
  - Alpine Shire
  - Ballarat
  - Banyule
  - Gannawarra
  - Baw Baw Shire
  - Bayside
  - Monash

### Documentation
- Add development warnings to CLAUDE.md

## Test Plan

- [ ] Verify each council implementation still fetches data correctly
- [ ] Test error scenarios (invalid address, API failures) return appropriate error types
- [ ] Confirm no TypeScript errors
- [ ] Ensure all linting checks pass