### PR TITLE
fix: optimize Campaspe council API by removing redundant combo contents call

### DIFF
--- a/convex/councils/campaspe.ts
+++ b/convex/councils/campaspe.ts
@@ -343,7 +343,7 @@ export async function fetchCampaspeData(placeDetails: GooglePlaceDetails) {
 		// Search directly with formatted address - no need for suggestions
 		// as Google Places provides well-formatted addresses
 
-		// Step 3: Search for the selected address
+		// Step 3: Search for the address
 		const wasteInfo = await searchAddress(
 			sessionId,
 			formTemplateId,


### PR DESCRIPTION
## Summary
- Removed the intermediate combo contents API call for Campaspe council
- Reduced API calls from 4 to 3 for better performance
- Maintained the same functionality while improving efficiency

## Test plan
- [ ] Test with a valid Campaspe Shire address
- [ ] Verify waste collection dates are still returned correctly
- [ ] Confirm the address search works without the combo suggestions step