### PR TITLE
[skip-review] fix: enable sticky comments in Claude Code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -123,7 +123,7 @@ jobs:
             Be constructive and helpful in your feedback.
 
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
-          # use_sticky_comment: true
+          use_sticky_comment: true
 
           # Optional: Customize review based on file types
           # direct_prompt: |


### PR DESCRIPTION
## Summary
- Enabled sticky comments in the Claude Code review workflow to prevent duplicate review comments
- This fixes the issue where Claude was creating new comments for each commit instead of updating the existing review

## Problem
As observed in PRs #16 and #18, Claude Code was posting duplicate review comments every time new commits were pushed to a PR. This was caused by the `use_sticky_comment: true` option being commented out in the workflow configuration.

## Solution
Uncommented the `use_sticky_comment: true` option in `.github/workflows/claude-code-review.yml`

## Test Plan
This PR itself will demonstrate the fix - any subsequent commits to this PR should update the existing Claude review comment rather than creating new ones.

## Related Issues
- Fixes duplicate review behavior seen in PR #16 and PR #18